### PR TITLE
Update video_info.py - Error when nb_frames was missing

### DIFF
--- a/ffmpegcv/video_info.py
+++ b/ffmpegcv/video_info.py
@@ -21,6 +21,9 @@ def get_info(video:str):
     assert (root[0].tag, root[0][0].tag) == ("streams", "stream")
     vinfo = root[0][0].attrib
 
+    if ('nb_frames' not in vinfo) :
+        vinfo['nb_frames'] = 0
+
     VideoInfo = namedtuple(
         "VideoInfo", ["width", "height", "fps", "count", "codec", "duration"]
     )


### PR DESCRIPTION
Some stream or video attributes could be missing in files metadata info.