### PR TITLE
修复某些时候data_id是队列中的通知信号，而非循环序号iloop，导致arr[True]，而不是arr[iloop]

### DIFF
--- a/ffmpegcv/ffmpeg_reader_noblock.py
+++ b/ffmpegcv/ffmpeg_reader_noblock.py
@@ -44,7 +44,7 @@ class FFmpegReaderNoblock(FFmpegReader):
         
         self.q.get() # 等待子进程写入
         data_id = self.q.get() # 读取子进程写入的数据
-        if data_id is None:
+        if data_id is None and not isinstance(data_id, int):
             return False, None
         else:
             self.iframe += 1


### PR DESCRIPTION
修复一个非常随机又阴险的bug，某些时候data_id是队列中的通知信号（那个anything=True），而非循环序号iloop，导致arr[True]，而不是arr[iloop]
arr[True]的时候等效于给arr升维，也就是[arr]

看看这个就很明白了
![image](https://github.com/chenxinfeng4/ffmpegcv/assets/5842006/1d4add28-e231-45e1-88b9-696492a45e17)
![image](https://github.com/chenxinfeng4/ffmpegcv/assets/5842006/51ff4abb-a677-4223-b951-975235ef97f6)
