### PR TITLE
Add timeout for stream videos

### DIFF
--- a/ffmpegcv/__init__.py
+++ b/ffmpegcv/__init__.py
@@ -383,7 +383,8 @@ def VideoCaptureStream(
     crop_xywh=None,
     resize=None,
     resize_keepratio=True,
-    resize_keepratioalign="center"
+    resize_keepratioalign="center",
+    timeout=None
 ) -> FFmpegReaderStream:
     """
     Alternative to cv2.VideoCapture
@@ -397,6 +398,7 @@ def VideoCaptureStream(
     resize  : see ffmpegcv.VideoReader
     resize_keepratio : see ffmpegcv.VideoReader
     resize_keepratioalign : see ffmpegcv.VideoReader
+    timeout : waits in seconds for stream video to connect
 
     Examples
     --------
@@ -435,7 +437,8 @@ def VideoCaptureStream(
         crop_xywh,
         resize,
         resize_keepratio,
-        resize_keepratioalign
+        resize_keepratioalign,
+        timeout
     )
 
 
@@ -450,7 +453,8 @@ def VideoCaptureStreamRT(
     resize=None,
     resize_keepratio=True,
     resize_keepratioalign="center",
-    gpu=None
+    gpu=None,
+    timeout=None
 ) -> FFmpegReaderStreamRT:
     if gpu is None:
         return FFmpegReaderStreamRT.VideoReader(
@@ -460,7 +464,8 @@ def VideoCaptureStreamRT(
             crop_xywh,
             resize,
             resize_keepratio,
-            resize_keepratioalign
+            resize_keepratioalign,
+            timeout=timeout
         )
     else:
         return FFmpegReaderStreamRTNV.VideoReader(
@@ -471,7 +476,8 @@ def VideoCaptureStreamRT(
             resize,
             resize_keepratio,
             resize_keepratioalign,
-            gpu=gpu
+            gpu=gpu,
+            timeout=timeout
         )
 
 

--- a/ffmpegcv/ffmpeg_reader_stream.py
+++ b/ffmpegcv/ffmpeg_reader_stream.py
@@ -20,10 +20,11 @@ class FFmpegReaderStream(FFmpegReaderCAM):
         resize,
         resize_keepratio,
         resize_keepratioalign,
+        timeout
     ):
         
         vid = FFmpegReaderStream()
-        videoinfo = get_info(stream_url)
+        videoinfo = get_info(stream_url,timeout)
         vid.origin_width = videoinfo.width
         vid.origin_height = videoinfo.height
         vid.fps = videoinfo.fps
@@ -71,11 +72,12 @@ class FFmpegReaderStreamNV(FFmpegReaderCAM):
         resize,
         resize_keepratio,
         resize_keepratioalign,
-        gpu
+        gpu,
+        timeout
     ):
         numGPU = get_num_NVIDIA_GPUs()
         vid = FFmpegReaderStreamNV()
-        videoinfo = get_info(stream_url)
+        videoinfo = get_info(stream_url,timeout)
         vid.origin_width = videoinfo.width
         vid.origin_height = videoinfo.height
         vid.fps = videoinfo.fps

--- a/ffmpegcv/ffmpeg_reader_stream_realtime.py
+++ b/ffmpegcv/ffmpeg_reader_stream_realtime.py
@@ -1,9 +1,6 @@
-from .video_info import run_async
-from queue import Queue
 from ffmpegcv.ffmpeg_reader import (
     FFmpegReader, get_videofilter_cpu, get_outnumpyshape, 
     get_videofilter_gpu, get_num_NVIDIA_GPUs, decoder_to_nvidia)
-import numpy as np
 from ffmpegcv.stream_info import get_info
 
 
@@ -19,10 +16,11 @@ class FFmpegReaderStreamRT(FFmpegReader):
         crop_xywh,
         resize,
         resize_keepratio,
-        resize_keepratioalign
+        resize_keepratioalign,
+        timeout
     ):
         vid = FFmpegReaderStreamRT()
-        videoinfo = get_info(stream_url)
+        videoinfo = get_info(stream_url,timeout)
         vid.origin_width = videoinfo.width
         vid.origin_height = videoinfo.height
         vid.fps = videoinfo.fps
@@ -63,9 +61,10 @@ class FFmpegReaderStreamRTNV(FFmpegReader):
         resize_keepratio,
         resize_keepratioalign,
         gpu,
+        timeout
     ):
         vid = FFmpegReaderStreamRTNV()
-        videoinfo = get_info(stream_url)
+        videoinfo = get_info(stream_url,timeout)
         vid.origin_width = videoinfo.width
         vid.origin_height = videoinfo.height
         vid.fps = videoinfo.fps

--- a/ffmpegcv/stream_info.py
+++ b/ffmpegcv/stream_info.py
@@ -4,10 +4,10 @@ import xml.etree.ElementTree as ET
 import shlex
 
 
-def get_info(stream_url):
+def get_info(stream_url, timeout=None):
     rtspflag = '-rtsp_transport tcp' if stream_url.startswith('rtsp://') else ''
     cmd = 'ffprobe -v quiet -print_format xml {} -select_streams v:0 -show_format -show_streams "{}"'.format(rtspflag, stream_url)
-    output = subprocess.check_output(shlex.split(cmd), shell=False)
+    output = subprocess.check_output(shlex.split(cmd), shell=False, timeout=timeout)
     root = ET.fromstring(output)
     assert (root[0].tag, root[0][0].tag) == ("streams", "stream")
     vinfo = root[0][0].attrib


### PR DESCRIPTION
Hi Chenxinfeng,

I have added a timeout in VideoCaptureStream and other related functions. 

When you want to connect to a streaming video and something goes wrong (like the camera being off or the network having a problem), the ffmpegcv waits infinitely, causing the entire application to become unresponsive and frozen.

With this timeout, VideoCaptureStream can wait a few seconds, and if failed to connect, it will release the memory and send an error.

I hope it helps. Thanks for your effort and time in developing such a handy library.