### PR TITLE
Add custom ffmpeg options in FFmpegWriter

### DIFF
--- a/ffmpegcv/ffmpeg_writer_qsv.py
+++ b/ffmpegcv/ffmpeg_writer_qsv.py
@@ -9,8 +9,10 @@ from .video_info import (
 
 class FFmpegWriterQSV(FFmpegWriter):
     @staticmethod
-    def VideoWriter(filename, codec, fps, pix_fmt, gpu, bitrate=None, resize=None, preset=None):
-        assert gpu is None or gpu == 0, 'Cannot use multiple QSV gpu yet.'
+    def VideoWriter(
+        filename, codec, fps, pix_fmt, gpu, bitrate=None, resize=None, preset=None, custom_ffmpeg_options: str = ""
+    ):
+        assert gpu is None or gpu == 0, "Cannot use multiple QSV gpu yet."
         numGPU = get_num_QSV_GPUs()
         assert numGPU
         gpu = int(gpu) % numGPU if gpu is not None else 0
@@ -31,6 +33,7 @@ class FFmpegWriterQSV(FFmpegWriter):
         vid = FFmpegWriterQSV()
         vid.fps = fps
         vid.codec, vid.pix_fmt, vid.filename = codec, pix_fmt, filename
+        vid.custom_ffmpeg_options = custom_ffmpeg_options
         vid.gpu = gpu
         vid.bitrate = bitrate
         vid.resize = resize


### PR DESCRIPTION

This pull request adds support for custom FFmpeg options in the `ffmpegcv` library. The changes primarily involve adding a new parameter `custom_ffmpeg_options` to the `VideoWriter` methods and updating the FFmpeg command construction to include these custom options.

Changes to support custom FFmpeg options:

* [`ffmpegcv/ffmpeg_writer.py`](diffhunk://#diff-078360b21a7b97628f2c257f706c3f177ea43e913c48cf1ccb38e910246afcd9L33-R36): Added `custom_ffmpeg_options` parameter to `VideoWriter` method and updated FFmpeg command construction to include this new parameter. [[1]](diffhunk://#diff-078360b21a7b97628f2c257f706c3f177ea43e913c48cf1ccb38e910246afcd9L33-R36) [[2]](diffhunk://#diff-078360b21a7b97628f2c257f706c3f177ea43e913c48cf1ccb38e910246afcd9R51-R79)
* [`ffmpegcv/ffmpeg_writer.py`](diffhunk://#diff-078360b21a7b97628f2c257f706c3f177ea43e913c48cf1ccb38e910246afcd9R18): Added `custom_ffmpeg_options` attribute to the `FFmpegWriter` class.
* [`ffmpegcv/ffmpeg_writer.py`](diffhunk://#diff-078360b21a7b97628f2c257f706c3f177ea43e913c48cf1ccb38e910246afcd9L104-R113): Added `custom_ffmpeg_options` parameter to `VideoWriter` method in `FFmpegWriterNV` class and updated FFmpeg command construction. [[1]](diffhunk://#diff-078360b21a7b97628f2c257f706c3f177ea43e913c48cf1ccb38e910246afcd9L104-R113) [[2]](diffhunk://#diff-078360b21a7b97628f2c257f706c3f177ea43e913c48cf1ccb38e910246afcd9R140-R160)
* [`ffmpegcv/ffmpeg_writer_qsv.py`](diffhunk://#diff-34d2f8203189f27659830c6a837e8c6e113af4415ada0521c30371ac08b43de6L12-R15): Added `custom_ffmpeg_options` parameter to `VideoWriter` method in `FFmpegWriterQSV` class and updated FFmpeg command construction. [[1]](diffhunk://#diff-34d2f8203189f27659830c6a837e8c6e113af4415ada0521c30371ac08b43de6L12-R15) [[2]](diffhunk://#diff-34d2f8203189f27659830c6a837e8c6e113af4415ada0521c30371ac08b43de6R36)